### PR TITLE
Maybe you'll like this one.

### DIFF
--- a/Source/Copy.cs
+++ b/Source/Copy.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Verse;
+using System.Xml;
+
+namespace PatchOperation
+{
+    public class Copy : PatchOperationPathed
+    {
+        protected override bool ApplyWorker(XmlDocument xml)
+        {
+            bool result = false;
+            IEnumerable<XmlNode> destinations = xml.SelectNodes(toXpath).Cast<XmlNode>();
+            if (!destinations.EnumerableNullOrEmpty())
+            {
+                foreach (XmlNode xmlNode in xml.SelectNodes(xpath).Cast<XmlNode>().ToArray())
+                {
+                    foreach (XmlNode xmlrecipient in destinations)
+                    {
+                        xmlrecipient.InnerXml = xmlNode.InnerXml;
+                        if (append != null)
+                        {
+                            xmlrecipient.InnerText = xmlrecipient.InnerText + append;
+                        }
+                        result = true;
+                    }
+                }
+            }
+            return result;
+        }
+        protected string toXpath;
+        protected string append = null;
+    }
+}

--- a/Source/PatchOperationHighlander.csproj
+++ b/Source/PatchOperationHighlander.csproj
@@ -12,11 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="System.Xml" />
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Just stumbled on this project and I might have something I can contribute. It's a patch operation that can copy values between nodes. I've also added an optional <append> parameter, which can add stuff to the copied value. Very useul for duplicating things like texture paths or descriptions that may or may not have been previously changed by other mods. Or for lazy people like me who dislike writing sequences of PatchOperationAdds for things that are similar.

Example use:

        <li Class="PatchOperation.Copy">
          <xpath>/Defs/ThingDef[defName = "GL_ClassyDoubleBed"]/graphicData/texPath</xpath>
          <toXpath>/Defs/ThingDef[defName = "GL_ClassyDoubleBed"]/uiIconPath</toXpath>
          <append>_south</append>
        </li>
